### PR TITLE
 visualiseur de DB sur interface graphique

### DIFF
--- a/app/docker-compose.yaml
+++ b/app/docker-compose.yaml
@@ -86,5 +86,16 @@ services:
     volumes:
       - db:/var/lib/mysql
 
+  phpmyadmin:
+    image: phpmyadmin/phpmyadmin
+    container_name: phpmyadmin
+    restart: always
+    ports:
+      - "8081:80"  # Accès via http://localhost:8081
+    environment:
+      PMA_HOST: mariadb
+      PMA_PORT: 3306
+    depends_on:
+      - mariadb 
 volumes:
   db:


### PR DESCRIPTION
Le but de ce conteneur " phpmyadmin"  ajouté , ecoutant sur le port "8081" est de nous faciliter la manip au niveau de la base de donnée (conteneur mariadb).
Ceci dis, au démarrage de notre docker-compose, nous aurions 5 conteneurs au lieu de 4 comme au préalable.

![docker_ps](https://github.com/user-attachments/assets/43da1a91-19b8-4075-b2b7-a66636990c71)
![test](https://github.com/user-attachments/assets/e780d001-e4a2-4085-81d2-81361953d40a)

